### PR TITLE
feat: カレンダーセルに学習時間を表示

### DIFF
--- a/PROJECT/script.js
+++ b/PROJECT/script.js
@@ -60,6 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
         let weeklyChart = null;
 
         function renderCalendar() {
+            const records = getLearningRecords();
             calendarGridEl.innerHTML = '';
             const year = currentDate.getFullYear();
             const month = currentDate.getMonth();
@@ -87,9 +88,23 @@ document.addEventListener('DOMContentLoaded', () => {
             for (let day = 1; day <= daysInMonth; day++) {
                 const dayCell = document.createElement('div');
                 dayCell.classList.add('day');
-                dayCell.textContent = day;
+
                 const dateStr = `${year}-${String(month + 1).padStart(2, '0')}-${String(day).padStart(2, '0')}`;
                 dayCell.dataset.date = dateStr;
+
+                // Add day number
+                const dayNumberEl = document.createElement('span');
+                dayNumberEl.textContent = day;
+                dayCell.appendChild(dayNumberEl);
+
+                // Find record for this day and display study time
+                const record = records.find(r => r.date === dateStr);
+                if (record && record.studyTimeMinutes > 0) {
+                    const studyTimeEl = document.createElement('div');
+                    studyTimeEl.classList.add('study-time');
+                    studyTimeEl.textContent = minutesToHHMM(record.studyTimeMinutes);
+                    dayCell.appendChild(studyTimeEl);
+                }
 
                 const today = new Date();
                 if (year === today.getFullYear() && month === today.getMonth() && day === today.getDate()) {

--- a/PROJECT/style.css
+++ b/PROJECT/style.css
@@ -109,3 +109,14 @@ body {
 #weekly-chart {
     max-height: 300px;
 }
+
+/* --- Study time in calendar cell --- */
+.study-time {
+    font-size: 0.75rem;
+    color: #6c757d;
+    margin-top: 4px;
+}
+
+.day.bg-primary .study-time {
+    color: #fff;
+}


### PR DESCRIPTION
GitHub issue #3 に対応。

カレンダーの日付セル内に、その日の合計学習時間を「HH:MM」形式で表示する機能を追加しました。

- `script.js`の`renderCalendar`関数を修正し、各日付の学習記録を検索して表示するロジックを追加。
- `style.css`に、追加された学習時間テキストのスタイルを定義。