### PR TITLE
Fix: Break time not being saved for the initial input group

### DIFF
--- a/record.html
+++ b/record.html
@@ -50,7 +50,7 @@
                     <div class="mb-3">
                         <label class="form-label">休憩時間</label>
                         <div id="break-times-container">
-                            <div class="mb-3 border p-2 rounded"> <!-- Initial break time group -->
+                            <div class="mb-3 border p-2 rounded break-time-group"> <!-- Initial break time group -->
                                 <div class="row">
                                     <div class="col-md-6">
                                         <div class="input-group mb-1">

--- a/script.js
+++ b/script.js
@@ -394,7 +394,6 @@ document.addEventListener('DOMContentLoaded', () => {
                 const newBreakTimeGroup = document.createElement('div');
                 newBreakTimeGroup.classList.add('mb-3', 'border', 'p-2', 'rounded', 'break-time-group');
                 newBreakTimeGroup.innerHTML = `
-                    <label class="form-label">休憩時間</label>
                     <div class="row">
                         <div class="col-md-6">
                             <div class="input-group mb-1">


### PR DESCRIPTION
The initial break time input group in `record.html` was missing the `break-time-group` class. This caused the JavaScript querySelector to miss this group, and as a result, any data entered into it was not saved.

This commit adds the missing class to the initial group, ensuring it is correctly processed and saved.

Additionally, this commit removes a redundant `<label>` that was being added every time a new break time group was created, which cleans up the UI.